### PR TITLE
Synchronize with NCO's change in WSR v3.2.0

### DIFF
--- a/ecflow/scripts/wsr/jwsr_main.ecf
+++ b/ecflow/scripts/wsr/jwsr_main.ecf
@@ -1,14 +1,12 @@
 #BSUB -J %E%wsr_main_%CYC%
-#BSUB -o /$COM%/output/%ENVIR%/today/wsr_main_%CYC%.o%J
+#BSUB -o %COM%/output/%ENVIR%/today/wsr_main_%CYC%.o%J
 #BSUB -L /bin/sh
 #BSUB -q %QUEUE%
 #BSUB -n 48
 #BSUB -W 00:45
-#BSUB -cwd /tmpnwprd
+#BSUB -cwd /tmp
 #BSUB -R span[ptile=16]
-#BSUB -x    # not_shared
 #BSUB -P %PROJ%-%PROJENVIR%
-#BSUB -a poe
 
 %include <head.h>
 %include <envir-p3.h>

--- a/ecflow/scripts/wsr/jwsr_prep.ecf
+++ b/ecflow/scripts/wsr/jwsr_prep.ecf
@@ -1,16 +1,12 @@
 #BSUB -J %E%wsr_prep_%CYC%
-#BSUB -o /%COM%/output/%ENVIR%/today/wsr_prep_%CYC%.o%J
+#BSUB -o %COM%/output/%ENVIR%/today/wsr_prep_%CYC%.o%J
 #BSUB -L /bin/sh
 #BSUB -q %QUEUE%
 #BSUB -W 01:20
-#BSUB -cwd /tmpnwprd
+#BSUB -cwd /tmp
 #BSUB -n 16
 #BSUB -R span[ptile=16]
-##BSUB -n 22
-##BSUB -R span[ptile=11]
-#BSUB -x
 #BSUB -P %PROJ%-%PROJENVIR%
-#BSUB -a poe
 
 %include <head.h>
 %include <envir-p3.h>
@@ -20,16 +16,16 @@ export cyc=%CYC%
 export MP_EUIDEVICE=sn_all
 export MP_EUILIB=us
 export MP_TASK_AFFINITY=core 
+export MP_PGMMODEL=mpmd
+export MP_CSS_INTERRUPT=yes
 
 model=wsr
 %include <model_ver.h>
 
-export MP_PGMMODEL=mpmd
-
-module load cfp
-export MP_CSS_INTERRUPT=yes
-
+module load impi/${impi_ver:?}
+module load CFP/${cfp_ver:?}
 module load grib_util/${grib_util_ver:?}
+module list
 
 ${HOMEwsr:?}/jobs/JWSR_PREP
 

--- a/jobs/JWSR_PREP
+++ b/jobs/JWSR_PREP
@@ -70,7 +70,7 @@ setpdy.sh
 ##############################
 # Define input COM Directory
 ##############################
-export COMINgens=${COMINgens:-$(compath.py gens/prod)}
+export COMINgens=${COMINgens:-$(compath.py gefs/prod)}
 export COMINcmce=${COMINcmce:-$(compath.py naefs/prod)}
 
 ##############################

--- a/libs/build.sh
+++ b/libs/build.sh
@@ -10,6 +10,7 @@ cp -pr $libdir/grib_api-1.9.16 $libdir/grib_api-1.9.16-working
 cd $libdir/grib_api-1.9.16-working
 rc=$?
 if (( rc == 0 )); then
+  module load ips/19.0.5.281
   module load jasper/1.900.1
   ecmwfdir=$libdir/ecmwf_grib_api-1.9.16
   ./configure \

--- a/ush/wsr_creategfs_1p0.sh
+++ b/ush/wsr_creategfs_1p0.sh
@@ -49,7 +49,7 @@ for CDATE in $date1 $date2 $date3 $date4; do
       rm poe_copygb_${mem}.$PDY$cyc
     fi
     for nfhrs in $hourlist; do
-      infile=${COMINgens}/gefs.${PDY}/$cyc/pgrb2ap5/ge${mem}.t${cyc}z.pgrb2a.0p50.f${nfhrs}    
+      infile=${COMINgens}/gefs.${PDY}/$cyc/atmos/pgrb2ap5/ge${mem}.t${cyc}z.pgrb2a.0p50.f${nfhrs}    
       outfile=$DATA/gefs.$PDY/$cyc/pgrb2a1p0/ge${mem}.t${cyc}z.pgrb2a.1p00.f${nfhrs}            
       if [ -s $infile ]; then 
         echo "${COPYGB2:?} -g \" $grid2 \" -x $infile $outfile" >> poe_copygb_${mem}.$PDY$cyc

--- a/versions/wsr.ver
+++ b/versions/wsr.ver
@@ -1,4 +1,4 @@
-export wsr_ver=v3.1.0
+export wsr_ver=v3.2.0
 export grib_util_ver=1.1.1
 
 export model_ver=$wsr_ver

--- a/versions/wsr.ver
+++ b/versions/wsr.ver
@@ -1,4 +1,7 @@
 export wsr_ver=v3.2.0
+export impi_ver=18.0.1
 export grib_util_ver=1.1.1
+export cfp_ver=2.0.2
 
-export model_ver=$wsr_ver
+export TMPDIR=${TMPDIR:-${DATAROOT:-/gpfs/dell1/nco/ops/tmpnwprd}}
+export PATH=.:$PATH


### PR DESCRIPTION
 On branch hotfix/sync_nco
	modified:   jobs/JWSR_PREP # Use gefs instead of gens
	modified:   libs/build.sh # Add loading ips lib to build libs/grib_api-1.9.16
	modified:   ush/wsr_creategfs_1p0.sh # Use GEFSv12 COM structure and naming convention
	modified:   versions/wsr.ver # Change to use v3.2.0

I compared "control, ecflow, fix,  grads,  jobs, parm,  README,  scripts,  sorc,  ush,  versions, libs/grib_api-1.9.16 and libs/build.sh", they are all identical.

Refs: #1