### PR TITLE
Merge NCO's current operational WSR (wsr.v3.2.2) to NOAA-EMC/WSR ops

### DIFF
--- a/jobs/JWSR_PREP
+++ b/jobs/JWSR_PREP
@@ -40,6 +40,8 @@ export jdim=37
 export ifort=1
 export icopygb=1
 
+# Specifically for testing ECMWF upgrade where the file name changes
+export ECMWF_FILE_EXT=${ECMWF_FILE_EXT:-1}
 ####################################
 # Determine Job Output Name on System
 ####################################

--- a/rocoto/user_full.conf
+++ b/rocoto/user_full.conf
@@ -1,7 +1,7 @@
 #SOURCEDIR              = /gpfs/dell2/emc/modeling/save/Dingchen.Hou/GIT/GEFS
 #
-SDATE                   = 2020112000
-EDATE                   = 2020112000
+SDATE                   = 2023050500
+EDATE                   = 2023050500
 npert                   = 30
 INCYC                   = 24
 #ACCOUNT                 = GEN-T2O

--- a/ush/wsr_createecmwf.sh
+++ b/ush/wsr_createecmwf.sh
@@ -160,7 +160,7 @@ if [[ $ifort -eq 1 ]]; then
 			###################################
 			# Copygb to convert - default     #
 			###################################
-			ensfile_lt=${ecdir}/DCE${ECDATE1}00${ECDATE2[$i]}001
+			ensfile_lt=${ecdir}/DCE${ECDATE1}00${ECDATE2[$i]}00${ECMWF_FILE_EXT}
 
 			ls -l $ensfile_lt
 			nsleep=0

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -18,3 +18,7 @@ export libjpeg_ver=9c
 export grib_util_ver=1.2.3
 
 export cfp_ver=2.0.4
+#HMU Added below for testing ecmwf upgrade in June 2023
+#export PDY=${PDY:-20230504}
+#export ECMWF_FILE_EXT="78"
+#export DCOMROOT=/lfs/h1/ops/dev/dcom


### PR DESCRIPTION
NCO has made changes to WSR to accommodate the ECMWF [upgrade](https://confluence.ecmwf.int/display/FCST/Implementation+of+IFS+Cycle+48r1).  Merge these changes to NOAA-EMC/WSR/ops. 