### PR TITLE
Update WSR version number for NOAA-EMC/WSR/develop

### DIFF
--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,4 +1,4 @@
-export wsr_ver=v3.3.1                  ## for ush/setup_wsr, ect
+export wsr_ver=v3.3.2                  ## for ush/setup_wsr, ect
 
 export ver_gefs=v12.3
 export ver_naefs=v6.1


### PR DESCRIPTION
The WSR version number is updated to the correct version from 3.3.1 to 3.3.2.