### PR TITLE
Sync NCO's changes for wsr.v3.3.3 to EMC/ops

### DIFF
--- a/jobs/JWSR_PREP
+++ b/jobs/JWSR_PREP
@@ -40,7 +40,7 @@ export jdim=37
 export ifort=1
 export icopygb=1
 
-# Specifically for testing ECMWF upgrade where the file name changes
+# Specifically for testing ECMWF upgrade where the file name changes 
 export ECMWF_FILE_EXT=${ECMWF_FILE_EXT:-1}
 ####################################
 # Determine Job Output Name on System
@@ -75,8 +75,8 @@ setpdy.sh
 ##############################
 # Define COM directories
 ##############################
-export COMINgens=${COMINgens:-$(compath.py prod/com/gefs/${ver_gefs})}
-export COMINcmce=${COMINcmce:-$(compath.py prod/naefs/${ver_naefs})}
+export COMINgens=${COMINgens:-$(compath.py prod/com/gefs/${gefs_ver})}
+export COMINcmce=${COMINcmce:-$(compath.py prod/naefs/${naefs_ver})}
 export DCOMROOT=${DCOMROOT:-${DCOMROOT}}
 export COMOUT=${COMOUT:-$(compath.py ${envir}/com/${NET}/${ver})/${RUN}.${PDY}/prep}
 

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,7 +1,7 @@
-export wsr_ver=v3.3.0                  ## for ush/setup_wsr, ect
+export wsr_ver=v3.3.2                  ## for ush/setup_wsr, ect
 
-export ver_gefs=v12.3
-export ver_naefs=v6.1
+export gefs_ver=v12.3
+export naefs_ver=v7.0
 
 export envvar_ver=1.0                  ## for ush/setup_wsr, ect
 export intel_ver=19.1.3.304


### PR DESCRIPTION
The following changes have been made so that EMC/ops matches NCO production:

- The WSR and NAEFS version have been upgraded. 
- `ver_gefs` and `ver_naefs` have been changed to `gefs_ver `and `naefs_ver`. 
- A space has been added to a comment in `JWSR_PREP` to match exactly to NCO's wsr.v3.3.3 package. 

This PR addresses issue #28.