### PR TITLE
Sync NCO's changes for wsr.v3.3.4 to EMC/ops

### DIFF
--- a/def/wsr00.def
+++ b/def/wsr00.def
@@ -1,0 +1,16 @@
+suite para
+family primary
+family 00
+family wsr
+family v3.3
+ edit PACKAGEHOME '/lfs/h1/ops/%ENVIR%/packages/wsr.%wsr_ver%'
+ edit PROJ 'WSR'
+ task jwsr_prep
+    time 09:40
+    task jwsr_main
+    defstatus complete
+  endfamily
+endfamily
+endfamily
+endfamily
+endsuite

--- a/def/wsr06.def
+++ b/def/wsr06.def
@@ -1,0 +1,16 @@
+suite para
+family primary
+family 06
+family wsr
+family v3.3
+ edit PACKAGEHOME '/lfs/h1/ops/%ENVIR%/packages/wsr.%wsr_ver%'
+ edit PROJ 'WSR'
+ task jwsr_prep
+    time 09:40
+    task jwsr_main
+    defstatus complete
+  endfamily
+endfamily
+endfamily
+endfamily
+endsuite

--- a/ecf/jwsr_prep.ecf
+++ b/ecf/jwsr_prep.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=1:20:00
-#PBS -l place=vscatter,select=1:ncpus=32:mem=3GB:mpiprocs=16:ompthreads=1
+#PBS -l thp=true
+#PBS -l place=vscatter:exclhost,select=1:ncpus=32:mem=220GB:mpiprocs=32:ompthreads=1:prepost=true
 #PBS -l debug=true
 
 export model=wsr

--- a/parm/transfer_wsr.list
+++ b/parm/transfer_wsr.list
@@ -31,10 +31,10 @@ _COMROOT_/wsr/_SHORTVER_/wsr._PDYm1_/
 B 1584
 Z
 
-_COMROOT_/wsr/_SHORTVER_/setup
+_COMROOT_/wsr/_SHORTVER_/setup/
 B 1234
 Z
 
-_COMROOT_/wsr/_SHORTVER_/wrapup
+_COMROOT_/wsr/_SHORTVER_/wrapup/
 B 1567
 Z

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,4 +1,4 @@
-export wsr_ver=v3.3.2                  ## for ush/setup_wsr, ect
+export wsr_ver=v3.3.4                  ## for ush/setup_wsr, ect, need to macth with wsr package version
 
 export gefs_ver=v12.3
 export naefs_ver=v7.0
@@ -18,7 +18,3 @@ export libjpeg_ver=9c
 export grib_util_ver=1.2.3
 
 export cfp_ver=2.0.4
-#HMU Added below for testing ecmwf upgrade in June 2023
-#export PDY=${PDY:-20230504}
-#export ECMWF_FILE_EXT="78"
-#export DCOMROOT=/lfs/h1/ops/dev/dcom


### PR DESCRIPTION
The following changes have been made so that `EMC/ops` matches those of NCO:

- Increase memory to 220 GB in `ecf/jwsr_prep.ecf ` to fix "Cgroup mem limit exceeded" issue
- Update `versions/run.ver` to remove commented lines and update `wsr_ver` to `v3.3.4` 
- Update `parm/transfer_wsr.list` to sync with NCO
- Add `def/`directory with definition files for ecf to sync with NCO