### PR TITLE
Modify which ECMWF files are being read for 50r1

### DIFF
--- a/ush/wsr_createecmwf.sh
+++ b/ush/wsr_createecmwf.sh
@@ -63,8 +63,8 @@ var[6]=":V:200 mb:"
 var[7]=":T:850 mb:"
 var[8]=":T:500 mb:"
 var[9]=":T:200 mb:"
-var[10]=":TP:"
-var[11]=":MSL:"
+var[10]=":TP:sfc:"
+var[11]=":MSL:sfc:"
 var[12]=":GH:500 mb:"
 var[13]=":U:700 mb:"
 var[14]=":V:700 mb:"
@@ -160,19 +160,27 @@ if [[ $ifort -eq 1 ]]; then
 			###################################
 			# Copygb to convert - default     #
 			###################################
-			ensfile_lt=${ecdir}/DCE${ECDATE1}00${ECDATE2[$i]}00${ECMWF_FILE_EXT}
+			ensfile_dce=${ecdir}/DCE${ECDATE1}00${ECDATE2[$i]}00${ECMWF_FILE_EXT}
+			if [[ ${lt[$i]} == "00" ]]; then
+				ensfile_dcd=${ecdir}/DCD${ECDATE1}00${ECDATE2[$i]}01${ECMWF_FILE_EXT}
+			else
+				ensfile_dcd=${ecdir}/DCD${ECDATE1}00${ECDATE2[$i]}00${ECMWF_FILE_EXT}
+			fi
 
-			ls -l $ensfile_lt
+			ls -l $ensfile_dce
+			ls -l $ensfile_dcd
 			nsleep=0
-			until [[ -s ${ensfile_lt} ]]; do
+			until [[ -s ${ensfile_dcd} && -s ${ensfile_dce} ]]; do
 				[[ $((nsleep+=1)) -gt $msleep ]] && exit 1
 				sleep $tsleep
 			done
-			filesiz=$(sizeof ${ensfile_lt})
-			if [[ filesiz -ge 135000000 ]]; then
+			filesiz_dce=$(sizeof ${ensfile_dce})
+			filesiz_dcd=$(sizeof ${ensfile_dcd})
+			if [[ $filesiz_dce -ge 135000000 && $filesiz_dcd -gt 2500000 ]]; then
 
 				> ecens.inv
-				${WGRIB:?} -s -PDS $ensfile_lt  >> ecens.inv
+				[[ -s $ensfile_dcd ]] && ${WGRIB:?} -s -PDS $ensfile_dcd >> ecens.inv
+				[[ -s $ensfile_dce ]] && ${WGRIB:?} -s -PDS $ensfile_dce >> ecens.inv
 
 				(( itask = 0 ))
 				(( varid = 1 ))
@@ -187,10 +195,19 @@ if [[ $ifort -eq 1 ]]; then
 						[[ $nm -le 9 ]] && nm=0$nm
 						hex=$(echo "obase=16;ibase=10; $nm" | bc)
 						[[ $nm -le 15 ]] && hex=0${hex}
-
+						if [[ $nm -eq 0 ]]; then
+							if [[ ${lt[$i]} == "00" ]]; then
+								search_pattern="${var[varid]}anl:"
+							else
+								search_pattern="${var[varid]}.*:type=9:"
+							fi
+							src_file=$ensfile_dcd
+						else
+							search_pattern="${var[varid]}.*${hex}3300*"
+							src_file=$ensfile_dce
+						fi
 						cat <<- EOF >> $cmdfile
-							#/usr/bin/egrep -i "${var[varid]}.*${hex}3300*" ecens.inv |cut -f1-2 -d :|${WGRIB:?} -i -grib $ensfile_lt -o ${WORK}/pgb.${fnum}
-							/bin/egrep -i "${var[varid]}.*${hex}3300*" ecens.inv |cut -f1-2 -d :|${WGRIB:?} -i -grib $ensfile_lt -o ${WORK}/pgb.${fnum}
+							/bin/egrep -i "${search_pattern}" ecens.inv |cut -f1-2 -d :|${WGRIB:?} -i -grib $src_file -o ${WORK}/pgb.${fnum}
 							if [[ $icopygb -eq 1 ]]; then
 								${COPYGB:?} -g2 -i1 -x pgb.${fnum} pgb_use.${fnum}
 								rm pgb.${fnum}
@@ -235,6 +252,7 @@ if [[ $ifort -eq 1 ]]; then
 				$wsrmpexec  -n 32 cfp ecmd.file
 
 				/bin/rm DCE*
+				/bin/rm DCD*
 			fi
 
 		done

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,4 +1,4 @@
-export wsr_ver=v3.3.4                  ## for ush/setup_wsr, ect, need to macth with wsr package version
+export wsr_ver=v3.3.5                  ## for ush/setup_wsr, ect, need to macth with wsr package version
 
 export gefs_ver=v12.3
 export naefs_ver=v7.0


### PR DESCRIPTION
This PR is similar to PR #35, but it is based on the `ops` branch instead of the `develop` branch.  The `develop` branch included a few changes in past commits that are not present in `ops`. The changes from those past commits are not needed for the wsr.v.3.3.5 release. The changes related to the ECMWF upgrade are exactly the same as in PR #35. 

The description from the original PR is below for completeness: 

This PR updates `ush/wsr_createecmwf.sh` so that the ECMWF 50r1 data needed in the `wsr_prep` task can be processed.

Addresses #34 